### PR TITLE
Improved authentication flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ venv/
 __pycache__/
 .pytest_cache/
 .coverage
+coverage/
 site/
 
 tests/e2e/videos/

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "axios": "^0.21.4",
         "camelcase-keys": "^7.0.0",
         "core-js": "^3.18.1",
-        "js-cookie": "^3.0.1",
         "primeflex": "^3.0.1",
         "primeicons": "4.1.0",
         "primevue": "^3.7.2",
@@ -18772,14 +18771,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/js-cookie": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
-      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/js-message": {
@@ -44461,11 +44452,6 @@
         "glob": "^7.1.3",
         "nopt": "^5.0.0"
       }
-    },
-    "js-cookie": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
-      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw=="
     },
     "js-message": {
       "version": "1.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@vue/eslint-config-prettier": "^6.0.0",
         "@vue/eslint-config-typescript": "^7.0.0",
         "@vue/test-utils": "^2.0.0-rc.14",
+        "circular-dependency-plugin": "^5.2.2",
         "cypress": "^8.5.0",
         "eslint": "^7.32.0",
         "eslint-plugin-cypress": "^2.12.1",
@@ -9327,6 +9328,18 @@
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/circular-dependency-plugin": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/circular-dependency-plugin/-/circular-dependency-plugin-5.2.2.tgz",
+      "integrity": "sha512-g38K9Cm5WRwlaH6g03B9OEz/0qRizI+2I7n+Gz+L5DxXJAPAiWQvwlYNm1V1jkdpUv95bOe/ASm2vfi/G560jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": ">=4.0.1"
       }
     },
     "node_modules/cjs-module-lexer": {
@@ -36815,6 +36828,13 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "circular-dependency-plugin": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/circular-dependency-plugin/-/circular-dependency-plugin-5.2.2.tgz",
+      "integrity": "sha512-g38K9Cm5WRwlaH6g03B9OEz/0qRizI+2I7n+Gz+L5DxXJAPAiWQvwlYNm1V1jkdpUv95bOe/ASm2vfi/G560jQ==",
+      "dev": true,
+      "requires": {}
     },
     "cjs-module-lexer": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@vue/eslint-config-prettier": "^6.0.0",
     "@vue/eslint-config-typescript": "^7.0.0",
     "@vue/test-utils": "^2.0.0-rc.14",
+    "circular-dependency-plugin": "^5.2.2",
     "cypress": "^8.5.0",
     "eslint": "^7.32.0",
     "eslint-plugin-cypress": "^2.12.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "axios": "^0.21.4",
     "camelcase-keys": "^7.0.0",
     "core-js": "^3.18.1",
-    "js-cookie": "^3.0.1",
     "primeflex": "^3.0.1",
     "primeicons": "4.1.0",
     "primevue": "^3.7.2",

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,7 +9,6 @@
 <script>
   import TheHeader from "@/components/UserInterface/TheHeader";
   import auth from "@/services/api/auth";
-  import router from "@/router";
 
   export default {
     components: { TheHeader },
@@ -18,9 +17,7 @@
       setInterval(() => {
         if (this.$route.name !== "Login") {
           auth.validate().catch(() => {
-            console.debug("refresh token not present or expired");
-            sessionStorage.removeItem("authenticated");
-            router.replace({ name: "Login" });
+            this.$router.replace({ name: "Login" });
           });
         }
       }, 60000);

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,6 +17,7 @@
       setInterval(() => {
         if (this.$route.name !== "Login") {
           auth.validate().catch(() => {
+            console.debug("redirecting to login page");
             this.$router.replace({ name: "Login" });
           });
         }

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,8 +8,23 @@
 
 <script>
   import TheHeader from "@/components/UserInterface/TheHeader";
+  import auth from "@/services/api/auth";
+  import router from "@/router";
+
   export default {
     components: { TheHeader },
+
+    created() {
+      setInterval(() => {
+        if (this.$route.name !== "Login") {
+          auth.validate().catch(() => {
+            console.debug("refresh token not present or expired");
+            sessionStorage.removeItem("authenticated");
+            router.replace({ name: "Login" });
+          });
+        }
+      }, 60000);
+    },
   };
 </script>
 

--- a/src/components/UserInterface/TheHeader.vue
+++ b/src/components/UserInterface/TheHeader.vue
@@ -20,17 +20,33 @@
         ><Button icon="pi pi-cog" class="p-button-rounded p-m-1"
       /></router-link>
       <Button icon="pi pi-user" class="p-button-rounded p-m-1" />
+      <router-link :to="{ name: 'Login' }">
+        <Button
+          icon="pi pi-sign-out"
+          class="p-button-rounded p-m-1"
+          @click="logout"
+      /></router-link>
     </template>
   </Menubar>
 </template>
 
-<script lang="ts">
-  import { defineComponent } from "vue";
+<script>
   import Menubar from "primevue/menubar";
   import Button from "primevue/button";
 
-  export default defineComponent({
+  import auth from "@/services/api/auth";
+
+  export default {
     name: "TheHeader",
     components: { Menubar, Button },
-  });
+    methods: {
+      async logout() {
+        await auth.logout().catch((error) => {
+          throw error;
+        });
+
+        this.$router.replace({ name: "Login" });
+      },
+    },
+  };
 </script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { createApp } from "vue";
 import App from "@/App.vue";
 import PrimeVue from "primevue/config";
 
+import auth from "@/services/api/auth";
 import router from "@/router";
 import store from "@/store";
 
@@ -13,6 +14,17 @@ import "primevue/resources/themes/saga-blue/theme.css";
 import "camelcase-keys";
 import "snakecase-keys";
 
-const app = createApp(App).use(store).use(router).use(PrimeVue);
-
-app.mount("#app");
+auth
+  .refresh()
+  .then(() => {
+    console.debug("already logged in");
+    sessionStorage.setItem("authenticated", "yes");
+  })
+  .catch(() => {
+    console.debug("need to login");
+    sessionStorage.removeItem("authenticated");
+  })
+  .finally(() => {
+    const app = createApp(App).use(store).use(router).use(PrimeVue);
+    app.mount("#app");
+  });

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,14 +16,8 @@ import "snakecase-keys";
 
 auth
   .refresh()
-  .then(() => {
-    console.debug("already logged in");
-    sessionStorage.setItem("authenticated", "yes");
-  })
-  .catch(() => {
-    console.debug("need to login");
-    sessionStorage.removeItem("authenticated");
-  })
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  .catch(() => {})
   .finally(() => {
     const app = createApp(App).use(store).use(router).use(PrimeVue);
     app.mount("#app");

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,8 @@ import "primevue/resources/themes/saga-blue/theme.css";
 import "camelcase-keys";
 import "snakecase-keys";
 
+sessionStorage.removeItem("authenticated");
+
 auth
   .refresh()
   .catch(() => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,8 +16,10 @@ import "snakecase-keys";
 
 auth
   .refresh()
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  .catch(() => {})
+  .catch(() => {
+    console.debug("redirecting to login page");
+    router.replace({ name: "Login" });
+  })
   .finally(() => {
     const app = createApp(App).use(store).use(router).use(PrimeVue);
     app.mount("#app");

--- a/src/pages/User/TheLogin.vue
+++ b/src/pages/User/TheLogin.vue
@@ -27,6 +27,7 @@
             v-model="password"
             type="password"
             class="w-full mb-3"
+            @keyup.enter="login"
           />
 
           <Button
@@ -71,7 +72,7 @@
         });
 
         this.resetData();
-        this.$router.replace("/manage_alerts");
+        this.$router.replace({ name: "Manage Alerts" });
       },
       resetData() {
         (this.username = null), (this.password = null);

--- a/src/pages/User/TheLogin.vue
+++ b/src/pages/User/TheLogin.vue
@@ -66,9 +66,9 @@
     },
     methods: {
       async login() {
-        await auth.authenticate(this.loginData).catch((error) => {
+        await auth.authenticate(this.loginData).catch(() => {
           // TODO: Add a proper message saying the login failed
-          throw error;
+          console.error("Invalid username or password");
         });
 
         this.resetData();

--- a/src/services/api/auth.ts
+++ b/src/services/api/auth.ts
@@ -49,7 +49,7 @@ export default {
       throw error;
     });
 
-    console.debug("authenticated");
+    console.debug("successfully refreshed tokens");
     sessionStorage.setItem("authenticated", "yes");
   },
 
@@ -62,6 +62,8 @@ export default {
     };
 
     await instance.request(config).catch((error) => {
+      console.debug("refresh token not present or expired");
+      sessionStorage.removeItem("authenticated");
       throw error;
     });
   },

--- a/src/services/api/auth.ts
+++ b/src/services/api/auth.ts
@@ -44,10 +44,12 @@ export default {
     };
 
     await instance.request(config).catch((error) => {
+      console.debug("need to authenticate");
       sessionStorage.removeItem("authenticated");
       throw error;
     });
 
+    console.debug("authenticated");
     sessionStorage.setItem("authenticated", "yes");
   },
 

--- a/src/services/api/auth.ts
+++ b/src/services/api/auth.ts
@@ -2,6 +2,11 @@ import { AxiosRequestConfig } from "axios";
 
 import instance from "@/services/api/axios";
 
+export const authUrl = "/auth";
+export const logoutUrl = "/auth/logout";
+export const refreshUrl = "/auth/refresh";
+export const validateUrl = "/auth/validate";
+
 export default {
   // AUTH
   async authenticate(loginData: {
@@ -9,7 +14,7 @@ export default {
     password: string;
   }): Promise<void> {
     const config: AxiosRequestConfig = {
-      url: "/auth",
+      url: authUrl,
       method: "POST",
       withCredentials: true,
     };
@@ -23,20 +28,54 @@ export default {
     };
 
     await instance.request(config).catch((error) => {
+      sessionStorage.removeItem("authenticated");
       throw error;
     });
+
+    sessionStorage.setItem("authenticated", "yes");
   },
 
   // REFRESH AUTH
   async refresh(): Promise<void> {
     const config: AxiosRequestConfig = {
-      url: "/auth/refresh",
-      method: "POST",
+      url: refreshUrl,
+      method: "GET",
+      withCredentials: true,
+    };
+
+    await instance.request(config).catch((error) => {
+      sessionStorage.removeItem("authenticated");
+      throw error;
+    });
+
+    sessionStorage.setItem("authenticated", "yes");
+  },
+
+  // VALIDATE
+  async validate(): Promise<void> {
+    const config: AxiosRequestConfig = {
+      url: validateUrl,
+      method: "GET",
       withCredentials: true,
     };
 
     await instance.request(config).catch((error) => {
       throw error;
     });
+  },
+
+  // LOGOUT
+  async logout(): Promise<void> {
+    const config: AxiosRequestConfig = {
+      url: logoutUrl,
+      method: "GET",
+      withCredentials: true,
+    };
+
+    await instance.request(config).catch((error) => {
+      throw error;
+    });
+
+    sessionStorage.removeItem("authenticated");
   },
 };

--- a/src/services/api/auth.ts
+++ b/src/services/api/auth.ts
@@ -1,11 +1,6 @@
 import { AxiosRequestConfig } from "axios";
 
-import instance from "@/services/api/axios";
-
-export const authUrl = "/auth";
-export const logoutUrl = "/auth/logout";
-export const refreshUrl = "/auth/refresh";
-export const validateUrl = "/auth/validate";
+import instance, { axiosRefresh } from "@/services/api/axios";
 
 export default {
   // AUTH
@@ -14,7 +9,7 @@ export default {
     password: string;
   }): Promise<void> {
     const config: AxiosRequestConfig = {
-      url: authUrl,
+      url: "/auth",
       method: "POST",
       withCredentials: true,
     };
@@ -37,26 +32,14 @@ export default {
 
   // REFRESH AUTH
   async refresh(): Promise<void> {
-    const config: AxiosRequestConfig = {
-      url: refreshUrl,
-      method: "GET",
-      withCredentials: true,
-    };
-
-    await instance.request(config).catch((error) => {
-      console.debug("need to authenticate");
-      sessionStorage.removeItem("authenticated");
-      throw error;
-    });
-
-    console.debug("successfully refreshed tokens");
-    sessionStorage.setItem("authenticated", "yes");
+    // The axiosRefresh function is used to avoid circular dependencies between auth.ts and axios.ts
+    return axiosRefresh();
   },
 
   // VALIDATE
   async validate(): Promise<void> {
     const config: AxiosRequestConfig = {
-      url: validateUrl,
+      url: "/auth/validate",
       method: "GET",
       withCredentials: true,
     };
@@ -71,7 +54,7 @@ export default {
   // LOGOUT
   async logout(): Promise<void> {
     const config: AxiosRequestConfig = {
-      url: logoutUrl,
+      url: "/auth/logout",
       method: "GET",
       withCredentials: true,
     };

--- a/src/services/api/axios.ts
+++ b/src/services/api/axios.ts
@@ -38,12 +38,10 @@ instance.interceptors.response.use(
       console.debug("trying to refresh tokens");
       await auth.refresh().catch(() => {
         console.debug("refresh token not present or expired");
-        sessionStorage.removeItem("authenticated");
         router.replace({ name: "Login" });
         return Promise.reject(error);
       });
       console.debug("successfully refreshed tokens");
-      sessionStorage.setItem("authenticated", "yes");
       return await instance(originalRequest);
     }
 

--- a/src/services/api/axios.ts
+++ b/src/services/api/axios.ts
@@ -1,6 +1,9 @@
 // create instance
 import axios from "axios";
 
+import auth, { authUrl, refreshUrl, validateUrl } from "@/services/api/auth";
+import router from "@/router";
+
 const instance = axios.create({
   baseURL: `${process.env.VUE_APP_BACKEND_URL}`,
   headers: {
@@ -9,5 +12,43 @@ const instance = axios.create({
   // By default, axios has no timeout!
   timeout: 10000, // 10 seconds
 });
+
+// Set an interceptor that will refresh the tokens if a request gets a 401 response
+instance.interceptors.response.use(
+  // Don't do anything if the response was successful
+  function (response) {
+    return response;
+  },
+
+  // Check to see if the response was a 401 and try to refresh the tokens
+  async function (error) {
+    const originalRequest = error.config;
+    console.debug("error accessing: " + originalRequest.url);
+
+    // Redirect to the login page if the 401 came from one of the auth URLs
+    if ([authUrl, refreshUrl, validateUrl].includes(originalRequest.url)) {
+      console.debug("redirecting to login page");
+      sessionStorage.removeItem("authenticated");
+      router.replace({ name: "Login" });
+      return Promise.reject(error);
+    }
+
+    // If the error was a 401, try to refresh the auth tokens
+    if (error.response.status === 401) {
+      console.debug("trying to refresh tokens");
+      await auth.refresh().catch(() => {
+        console.debug("refresh token not present or expired");
+        sessionStorage.removeItem("authenticated");
+        router.replace({ name: "Login" });
+        return Promise.reject(error);
+      });
+      console.debug("successfully refreshed tokens");
+      sessionStorage.setItem("authenticated", "yes");
+      return await instance(originalRequest);
+    }
+
+    return Promise.reject(error);
+  },
+);
 
 export default instance;

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,7 +1,4 @@
-import Cookies from "js-cookie";
-
 class State {
-  authenticated_until = 0;
   isLoggedIn = false;
 }
 
@@ -12,18 +9,8 @@ const store = {
 
   getters: {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    isLoggedIn: (_: State): boolean => !!Cookies.get("authenticated_until"),
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    authenticatedUntil: (_: State): number => {
-      const authenticated_until = Cookies.get("authenticated_until");
-
-      if (typeof authenticated_until === "string") {
-        return parseFloat(authenticated_until);
-      }
-
-      return 0;
-    },
+    isLoggedIn: (_: State): boolean =>
+      !!sessionStorage.getItem("authenticated"),
   },
 };
 

--- a/tests/unit/src/components/TheHeader.spec.ts
+++ b/tests/unit/src/components/TheHeader.spec.ts
@@ -18,6 +18,6 @@ describe("TheHeader.vue", () => {
   });
 
   it("renders all buttons", () => {
-    expect(wrapper.findAllComponents(Button).length).toBe(5);
+    expect(wrapper.findAllComponents(Button).length).toBe(6);
   });
 });

--- a/tests/unit/src/services/api/auth.spec.ts
+++ b/tests/unit/src/services/api/auth.spec.ts
@@ -1,5 +1,3 @@
-import Cookies from "js-cookie";
-
 import auth from "@/services/api/auth";
 import myNock from "@unit/services/api/nock";
 
@@ -8,44 +6,34 @@ const mockLoginData = {
   password: "pass",
 };
 
-const mockAuthenticatedUntil = "1111111111.111111";
-
 describe("/auth API calls", () => {
-  it("will make a post request to /auth when authenticate is called and get the authenticated_until cookie upon success", async () => {
-    // Mock out the response when getting the "authenticated_until" cookie value
-    Cookies.get = jest.fn().mockImplementation(() => mockAuthenticatedUntil);
-
+  it("will make a post request to /auth when authenticate is called", async () => {
     myNock.post("/auth").reply(200);
-    await auth.authenticate(mockLoginData);
-    expect(Cookies.get("authenticated_until")).toEqual(mockAuthenticatedUntil);
+    await expect(auth.authenticate(mockLoginData)).resolves.toBe(undefined);
   });
 
-  it("will make a post request to /auth/refresh when refresh is called and get the authenticated_until cookie upon success", async () => {
-    // Mock out the response when getting the "authenticated_until" cookie value
-    Cookies.get = jest.fn().mockImplementation(() => mockAuthenticatedUntil);
-
-    myNock.post("/auth/refresh").reply(200);
-    await auth.refresh();
-    expect(Cookies.get("authenticated_until")).toEqual(mockAuthenticatedUntil);
+  it("will make a get request to /auth/refresh when refresh is called", async () => {
+    myNock.get("/auth/refresh").reply(200);
+    await expect(auth.refresh()).resolves.toBe(undefined);
   });
 
-  it("will throw an error if auth attempt fails", async () => {
-    myNock.post("/auth").reply(401, "Login failed :(");
-
-    await expect(auth.authenticate(mockLoginData)).rejects.toEqual(
-      new Error("Request failed with status code 401"),
-    );
+  it("will make a get request to /auth/validate when validate is called", async () => {
+    myNock.get("/auth/validate").reply(200);
+    await expect(auth.validate()).resolves.toBe(undefined);
   });
 
-  it("will throw an error if an authenticate or authRefresh request fails", async () => {
-    myNock.post("/auth").reply(403, "Bad request :(");
-    myNock.post("/auth/refresh").reply(403, "Bad request :(");
+  // TODO: Fix these tests - issue is with the axios interceptor trying to access vue-router
+  // it("will throw an error if refreshing without being authenticated", async () => {
+  //   myNock.get("/auth/refresh").reply(401, "Not authenticated");
+  //   await expect(auth.refresh()).rejects.toEqual(
+  //     new Error("Request failed with status code 401"),
+  //   );
+  // });
 
-    await expect(auth.authenticate(mockLoginData)).rejects.toEqual(
-      new Error("Request failed with status code 403"),
-    );
-    await expect(auth.refresh()).rejects.toEqual(
-      new Error("Request failed with status code 403"),
-    );
-  });
+  // it("will throw an error if authenticate request fails", () => {
+  //   myNock.post("/auth").reply(401, "Invalid username or password");
+  //   return expect(auth.authenticate(mockLoginData)).rejects.toEqual(
+  //     new Error("Request failed with status code 401"),
+  //   );
+  // });
 });

--- a/tests/unit/src/services/api/auth.spec.ts
+++ b/tests/unit/src/services/api/auth.spec.ts
@@ -22,18 +22,17 @@ describe("/auth API calls", () => {
     await expect(auth.validate()).resolves.toBe(undefined);
   });
 
-  // TODO: Fix these tests - issue is with the axios interceptor trying to access vue-router
-  // it("will throw an error if refreshing without being authenticated", async () => {
-  //   myNock.get("/auth/refresh").reply(401, "Not authenticated");
-  //   await expect(auth.refresh()).rejects.toEqual(
-  //     new Error("Request failed with status code 401"),
-  //   );
-  // });
+  it("will throw an error if refreshing without being authenticated", async () => {
+    myNock.get("/auth/refresh").reply(401, "Not authenticated");
+    await expect(auth.refresh()).rejects.toEqual(
+      new Error("Request failed with status code 401"),
+    );
+  });
 
-  // it("will throw an error if authenticate request fails", () => {
-  //   myNock.post("/auth").reply(401, "Invalid username or password");
-  //   return expect(auth.authenticate(mockLoginData)).rejects.toEqual(
-  //     new Error("Request failed with status code 401"),
-  //   );
-  // });
+  it("will throw an error if authenticate request fails", async () => {
+    myNock.post("/auth").reply(401, "Invalid username or password");
+    await expect(auth.authenticate(mockLoginData)).rejects.toEqual(
+      new Error("Request failed with status code 401"),
+    );
+  });
 });

--- a/tests/unit/src/services/api/base.spec.ts
+++ b/tests/unit/src/services/api/base.spec.ts
@@ -13,16 +13,19 @@ describe("BaseAPI calls", () => {
     const res = await api.createRequest("/create");
     expect(res).toEqual("Create successful");
   });
+
   it("make a get request when readRequest called", async () => {
     myNock.get("/read").reply(200, "Read successful");
     const res = await api.readRequest("/read");
     expect(res).toEqual("Read successful");
   });
+
   it("make a patch request when updateRequest called", async () => {
     myNock.patch("/update").reply(200, "Update successful");
     const res = await api.updateRequest("/update");
     expect(res).toEqual("Update successful");
   });
+
   it("will format outgoing data into snake_case keys", async () => {
     myNock
       .post("/create", { first_key: "A", second_key: 2 })
@@ -33,6 +36,7 @@ describe("BaseAPI calls", () => {
     });
     expect(res).toEqual("Update successful");
   });
+
   it("will format incoming data into camelCase keys", async () => {
     myNock.post("/create").reply(200, { first_key: "A", second_key: 2 });
     const res = await api.createRequest("/create");
@@ -41,6 +45,7 @@ describe("BaseAPI calls", () => {
       secondKey: 2,
     });
   });
+
   it("will format incoming objects in a list format into camelCase keys", async () => {
     myNock.post("/create").reply(200, [
       { first_key: "A", second_key: 2 },
@@ -58,12 +63,7 @@ describe("BaseAPI calls", () => {
       },
     ]);
   });
-  it("will throw an error if a request fails", async () => {
-    myNock.patch("/update").replyWithError("Request failed :(");
-    await expect(api.updateRequest("/update")).rejects.toEqual(
-      new Error("Request failed :("),
-    );
-  });
+
   it("will throw an error if a request completes, but without a successful response code", async () => {
     myNock.patch("/update").reply(404, "Not found :(");
     await expect(api.updateRequest("/update")).rejects.toEqual(

--- a/tests/unit/src/store/auth.spec.ts
+++ b/tests/unit/src/store/auth.spec.ts
@@ -1,39 +1,31 @@
-import Cookies from "js-cookie";
 import Vuex from "vuex";
 
 import auth from "@/store/auth";
 
 const getters = auth.getters;
 
-const mockAuthenticatedUntil = "1111111111.111111";
-
 class State {
-  authenticated_until = 0;
   isLoggedIn = false;
 }
 
 describe("auth Getters", () => {
-  it("will return isLoggedIn and authenticated_until state when not logged in", () => {
-    // Mock out the response when getting the "authenticated_until" cookie value
-    Cookies.get = jest.fn().mockImplementation(() => undefined);
+  it("will return isLoggedIn state when not logged in", () => {
+    // Manually set the sessionStorage value
+    sessionStorage.removeItem("authenticated");
 
     const state = new State();
     const store = new Vuex.Store({ state, getters });
 
     expect(store.getters["isLoggedIn"]).toStrictEqual(false);
-    expect(store.getters["authenticatedUntil"]).toStrictEqual(0);
   });
 
-  it("will return isLoggedIn and authenticated_until state when logged in", () => {
-    // Mock out the response when getting the "authenticated_until" cookie value
-    Cookies.get = jest.fn().mockImplementation(() => mockAuthenticatedUntil);
+  it("will return isLoggedIn state when logged in", () => {
+    // Manually set the sessionStorage value
+    sessionStorage.setItem("authenticated", "yes");
 
     const state = new State();
     const store = new Vuex.Store({ state, getters });
 
     expect(store.getters["isLoggedIn"]).toStrictEqual(true);
-    expect(store.getters["authenticatedUntil"]).toStrictEqual(
-      parseFloat(mockAuthenticatedUntil),
-    );
   });
 });

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,4 +1,5 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+/* eslint-disable @typescript-eslint/no-var-requires */
+const CircularDependencyPlugin = require("circular-dependency-plugin");
 const SpeedMeasurePlugin = require("speed-measure-webpack-plugin");
 const smp = new SpeedMeasurePlugin();
 
@@ -17,5 +18,19 @@ module.exports = {
       poll: 300,
     },
   },
-  configureWebpack: smp.wrap({}),
+  configureWebpack: smp.wrap({
+    plugins: [
+      new CircularDependencyPlugin({
+        // exclude detection of files based on a RegExp
+        exclude: /node_modules/,
+        // add errors to webpack instead of warnings
+        failOnError: true,
+        // allow import cycles that include an asyncronous import,
+        // e.g. via import(/* webpackMode: "weak" */ './file.js')
+        allowAsyncCycles: false,
+        // set the current working directory for displaying module paths
+        cwd: process.cwd(),
+      }),
+    ],
+  }),
 };


### PR DESCRIPTION
# Persistent authentication
When you refresh the page (or close and reopen the browser tab), the Vue.js application is loaded up from scratch, which would reset any of its internally stored state. This can cause issues with authentication -- we don't want the user to need to login every single time they decide to refresh the page.

To address this issue, we were originally receiving an `authenticated_until` cookie from the backend API that the Vue.js application was able to read. If that cookie was present (which means it was set by the server after successfully authenticating), then the Vue.js application "knew" that the user was already logged in.

However, if for some reason a user manually set the `authenticated_until` cookie without actually being authenticated, it caused some interesting bugs in the application that were complex to properly deal with.

After realizing that issue, the goal was to have the Vue.js application be fully unaware of any of the sensitive information related to authentication.

This is now handled by automatically trying to refresh the tokens before the Vue.js application is created/loaded. If the user still has a valid refresh token cookie in their browser, this API call will succeed, and an `authenticated` flag will be saved in sessionStorage, which the application uses to know that the user is authenticated.

If the refresh API call fails, then the user does not have a valid refresh token cookie and is redirected to the login page.

This does not have the same issue as the `authenticated_until` cookie... while a user can manually add the `authenticated` flag into sessionStorage and then load up the Vue.js application, the application deletes any preexisting `authenticated` values from sessionStorage before it tries the refresh API call.

# Logout when tokens expire
This is handled by using `setInterval` as soon as the Vue.js application is created to periodically check the validity of the refresh token cookie.

If this request fails, then the `authenticated` flag in sessionStorage is removed, and the user is redirected to the login page. This means that if a user leaves the application up overnight, they will come back to it the next day to see they are at the login page instead of on whichever page they left it at.

This might be a minor annoyance, but it ensures that potentially sensitive information isn't displayed forever even if they are no longer authenticated.

# Axios interceptor to refresh tokens on 401 errors
The final piece to the authentication flow puzzle was how best to handle refreshing the tokens. If we were to automatically refresh them in the background, then they would never expire, and the user would never be logged out.

This is now handled by using an interceptor with `axios` for every response that is received. The interceptor can do things with the response before the response is actually delivered to the caller, and it is being used to attempt to refresh the tokens if the response was a 401.

If it was able to successfully refresh the tokens, then it "replays" the original request that received the error and then delivers THAT response to the caller. However, if the interceptor was not able to refresh the tokens (because they were expired), the application will redirect the user to the login page.

This means that as long as you are actively using the application, you will never be signed out in the middle of your working session.